### PR TITLE
Update hinclude.js

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -81,7 +81,7 @@ var hinclude;
       var callback = function(element, req) {};
       this.includes = document.getElementsByTagName("hx:include");
       if (this.includes.length === 0) { // remove ns for IE
-        hincludeincludes = document.getElementsByTagName("include");
+        this.includes = document.getElementsByTagName("include");
       }
       if (mode == "async") {
         callback = this.set_content_async;


### PR DESCRIPTION
When there are no include tags in the page, there is a JS error

```
Timestamp: 11/07/2012 01:08:09 PM
Error: ReferenceError: assignment to undeclared variable hincludeincludes
Source File: https://static.boxula.dev/js/compiled/10f3e23_hinclude_3.js
Line: 84
```
