### PR TITLE
Added `media` attribute support

### DIFF
--- a/demo/mobile
+++ b/demo/mobile
@@ -1,1 +1,1 @@
-narrow viewport!
+narrow viewport !

--- a/hinclude.js
+++ b/hinclude.js
@@ -193,3 +193,4 @@ var hinclude = {
 };
 
 hinclude.addDOMLoadEvent(function() { hinclude.run(); });
+

--- a/index.html
+++ b/index.html
@@ -103,6 +103,7 @@ In Responsive Web Design, it is a common pattern to load certain portions of the
 Using a `media` attribute, the `include` pattern can be used for this purpose.
 <p>For example, here you can see this page is viewed on a <hx:include src="demo/mobile" media="screen and (max-width: 600px)">not so narrow viewport</hx:include></p>
 
+
 </div>
 
 </body>


### PR DESCRIPTION
As we have discussed (long ago) on Twitter, I have added `media` attribute support.
Its goal is to facilitate use of the `<include>` pattern in Responsive Web Design, to load certain HTML portions of the page only for certain viewports.
