### PR TITLE
Fix for unsecure content warning in Internet Explorer.

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -192,7 +192,7 @@ var hinclude;
         /*@cc_on
         document.write(
           "<scr"
-            + "ipt id=__ie_onload defer src=javascript:void(0)><\/scr"
+            + "ipt id=__ie_onload defer src='//:'><\/scr"
             + "ipt>"
         );
         var script = document.getElementById("__ie_onload");


### PR DESCRIPTION
We encountered unsecure content warnings on SSL sites, even though we had no non-SSL content. Placing a script tag with `src="javascript:void(0);"` makes IE think it's loading through an unsecure protocol. Loading `//:` instead fixed our problem as described [here](http://blog.httpwatch.com/2009/09/17/even-more-problems-with-the-ie-8-mixed-content-warning/).
