### PR TITLE
Add cookie test

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -101,17 +101,23 @@ var hinclude;
         element.innerHTML = data;
       } else {
         var req = false;
-        if (window.XMLHttpRequest) {
-          try {
-            req = new XMLHttpRequest();
-          } catch (e1) {
+        // test if the element has a claimed cookie
+        var cookie_name = element.getAttribute("cookie");
+        if (cookie_name && !this.has_cookie(cookie_name)) {
             req = false;
-          }
-        } else if (window.ActiveXObject) {
-          try {
-            req = new ActiveXObject("Microsoft.XMLHTTP");
-          } catch (e2) {
-            req = false;
+        } else {
+          if (window.XMLHttpRequest) {
+            try {
+              req = new XMLHttpRequest();
+            } catch (e1) {
+              req = false;
+            }
+          } else if (window.ActiveXObject) {
+            try {
+              req = new ActiveXObject("Microsoft.XMLHTTP");
+            } catch (e2) {
+              req = false;
+            }
           }
         }
         if (req) {
@@ -152,6 +158,21 @@ var hinclude;
         }
       }
       return value_default;
+    },
+
+    has_cookie: function(name) {
+      var dc = '; ' + document.cookie + ';';
+      var prefix = "; " + name + "=";
+      var begin = dc.indexOf(prefix);
+
+      // begin === -1 means that the key is not found in the cookie string
+      if (begin === -1) {
+        return false;
+      }
+      // test if the cookie is empty
+      // Example, "test" cookie is empty will store : "[...]; test=;[...]" in the cookie string
+      begin = dc.indexOf(prefix + ';');
+      return (begin === -1);
     },
 
     /*

--- a/hinclude.js
+++ b/hinclude.js
@@ -59,8 +59,9 @@ var hinclude;
     },
 
     show_buffered_content: function () {
+      var include;
       while (hinclude.buffer.length > 0) {
-        var include = hinclude.buffer.pop();
+        include = hinclude.buffer.pop();
         if (include[1].status === 200 || include[1].status === 304) {
           include[0].innerHTML = include[1].responseText;
         }
@@ -73,7 +74,7 @@ var hinclude;
     run: function () {
       var i = 0;
       var mode = this.get_meta("include_mode", "buffered");
-      var callback = function (element, req) {};
+      var callback;
       this.includes = document.getElementsByTagName("hx:include");
       if (this.includes.length === 0) { // remove ns for IE
         this.includes = document.getElementsByTagName("include");
@@ -104,7 +105,7 @@ var hinclude;
         // test if the element has a claimed cookie
         var cookie_name = element.getAttribute("cookie");
         if (cookie_name && !this.has_cookie(cookie_name)) {
-            req = false;
+          req = false;
         } else {
           if (window.XMLHttpRequest) {
             try {
@@ -123,7 +124,9 @@ var hinclude;
         if (req) {
           this.outstanding += 1;
           req.onreadystatechange = function () {
-            incl_cb(element, req);
+            if (typeof incl_cb === 'function') {
+              incl_cb(element, req);
+            }
           };
           try {
             req.open("GET", url, true);
@@ -138,9 +141,7 @@ var hinclude;
 
     refresh: function (element_id) {
       var i = 0;
-      var mode = this.get_meta("include_mode", "buffered");
-      var callback = function (element, req) {};
-      callback = this.set_content_buffered;
+      var callback = this.set_content_buffered;
       for (i; i < this.includes.length; i += 1) {
         if (this.includes[i].getAttribute("id") === element_id) {
           this.include(this.includes[i], this.includes[i].getAttribute("src"), callback);
@@ -151,8 +152,9 @@ var hinclude;
     get_meta: function (name, value_default) {
       var m = 0;
       var metas = document.getElementsByTagName("meta");
+      var meta_name;
       for (m; m < metas.length; m += 1) {
-        var meta_name = metas[m].getAttribute("name");
+        meta_name = metas[m].getAttribute("name");
         if (meta_name === name) {
           return metas[m].getAttribute("content");
         }

--- a/hinclude.js
+++ b/hinclude.js
@@ -103,8 +103,19 @@ var hinclude;
       } else {
         var req = false;
         // test if the element has a claimed cookie
-        var cookie_name = element.getAttribute("cookie");
-        if (cookie_name && !this.has_cookie(cookie_name)) {
+        var cookie_value = element.getAttribute("cookie");
+        var hasCookie = false;
+        if (cookie_value) {
+          var cookie_list = cookie_value.split('||');
+          var i;
+          for (i in cookie_list) {
+            if (cookie_list.hasOwnProperty(i) && this.has_cookie(cookie_list[i].trim())) {
+              hasCookie = true;
+              break;
+            }
+          }
+        }
+        if (cookie_value && !hasCookie) {
           req = false;
         } else {
           if (window.XMLHttpRequest) {

--- a/hinclude.js
+++ b/hinclude.js
@@ -160,7 +160,7 @@ var hinclude;
       return value_default;
     },
 
-    has_cookie: function(name) {
+    has_cookie: function (name) {
       var dc = '; ' + document.cookie + ';';
       var prefix = "; " + name + "=";
       var begin = dc.indexOf(prefix);


### PR DESCRIPTION
Add a simple test if the ```<hx:``` tag has a ```cookie="cookie_name"``` attribute.
The include request will be executed only if a cookie matching the ```cookie_name``` is found.

This fixes #35