### PR TITLE
Add ready Event

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -44,7 +44,9 @@ var hinclude;
           element.innerHTML = req.responseText;
         }
         element.className = hinclude.classprefix + req.status;
-        element.dispatchEvent(new Event('ready'));
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent('ready', false, false, null);
+        element.dispatchEvent(evt);
       }
     },
 
@@ -56,7 +58,9 @@ var hinclude;
         if (hinclude.outstanding === 0) {
           hinclude.show_buffered_content();
         }
-        element.dispatchEvent(new Event('ready'));
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent('ready', false, false, null);
+        element.dispatchEvent(evt);
       }
     },
 
@@ -102,7 +106,9 @@ var hinclude;
       if (scheme.toLowerCase() === "data") { // just text/plain for now
         var data = decodeURIComponent(url.substring(url.indexOf(",") + 1, url.length));
         element.innerHTML = data;
-        element.dispatchEvent(new Event('ready'));
+        var evt = document.createEvent('CustomEvent');
+        evt.initCustomEvent('ready', false, false, null);
+        element.dispatchEvent(evt);
       } else {
         var req = false;
         if (window.XMLHttpRequest) {

--- a/hinclude.js
+++ b/hinclude.js
@@ -44,6 +44,7 @@ var hinclude;
           element.innerHTML = req.responseText;
         }
         element.className = hinclude.classprefix + req.status;
+        element.dispatchEvent(new Event('ready'));
       }
     },
 
@@ -55,6 +56,7 @@ var hinclude;
         if (hinclude.outstanding === 0) {
           hinclude.show_buffered_content();
         }
+        element.dispatchEvent(new Event('ready'));
       }
     },
 
@@ -100,6 +102,7 @@ var hinclude;
       if (scheme.toLowerCase() === "data") { // just text/plain for now
         var data = decodeURIComponent(url.substring(url.indexOf(",") + 1, url.length));
         element.innerHTML = data;
+        element.dispatchEvent(new Event('ready'));
       } else {
         var req = false;
         if (window.XMLHttpRequest) {


### PR DESCRIPTION
Sometimes you want to know when the hinclude is ended.
Exemple of use:
```
<hx:include src="/other/document/here.html" id="example"></hx:include>
<script>
    $('#example').on('ready', function(){
        console.log('hinclude is ended');
    });
</script>
```