### PR TITLE
Fix line endings and assets path

### DIFF
--- a/test/framework.js
+++ b/test/framework.js
@@ -28,7 +28,7 @@ function runTests(page_loc, tests, viewport) {
       console.log('BROWSER CONSOLE: ' + msg);
   };
 
-  page.open('http://localhost:' + port + '/' + page_loc, function (status) {
+  page.open('http://localhost:' + port + '/assets/' + page_loc, function (status) {
     if (status === "success") {
       console.log("testing " + port + "...");
     } else {


### PR DESCRIPTION
I tried to run the tests, but ran into Windows line endings in serve.sh.
serve.sh is now converted to use Unix file endings. I think using Unix
line endings is a good choice, since the test script is written in bash.

Also, the test script couldn't find the assets for some reason, so
I added the assets/ path in framework.js.