### PR TITLE
Run the tests with npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
-script: "cd test; make"
+script: "PORT=8080 npm test"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -10,9 +10,17 @@
       } 
     ],
      "dependencies" : {
-        "jslint"   :  "*"
+        "copyfiles": "^0.2.1",
+        "jslint"   :  "*",
+        "simplehttpserver": "0.0.6"
       },
     "engines": {
         "node": ">= 0.6.0"
+    },
+    "scripts": {
+      "copy": "copyfiles hinclude.js test/assets/",
+      "server": "simplehttpserver -p $PORT test/assets",
+      "test": "npm run copy; cd test; make test_port=$PORT",
+      "test_killall": "npm test; killall node"
     }
 }

--- a/test/Makefile
+++ b/test/Makefile
@@ -1,4 +1,3 @@
-test_port=8081
 test: basic none small_media large_media lint
 
 basic: server
@@ -16,4 +15,4 @@ lint:
 	node ../node_modules/jslint/bin/jslint.js ../hinclude.js
 
 server:
-	./serve.sh $(test_port)
+	npm run server &

--- a/test/framework.js
+++ b/test/framework.js
@@ -28,29 +28,31 @@ function runTests(page_loc, tests, viewport) {
       console.log('BROWSER CONSOLE: ' + msg);
   };
 
-  page.open('http://localhost:' + port + '/' + page_loc, function (status) {
-    if (status === "success") {
-      console.log("testing " + port + "...");
-    } else {
-      console.error("Open problem; bailing\n");
-      phantom.exit(2);
-    }
+  setTimeout(function(){
+    page.open('http://localhost:' + port + '/' + page_loc, function (status) {
+      if (status === "success") {
+        console.log("testing " + port + "...");
+      } else {
+        console.error("Open problem; bailing\n");
+        phantom.exit(2);
+      }
 
-    var i = 0;
-    while (i < tests.length) {
-      checkContent(tests[i][0], tests[i][1]);
-      i++;
-    }
+      var i = 0;
+      while (i < tests.length) {
+        checkContent(tests[i][0], tests[i][1]);
+        i++;
+      }
 
-    if (errors.length > 0) {
-      console.error(errors.join("\n"));
-      page.render("error.png");
-      phantom.exit(1);
-    } else {
-      phantom.exit(0);
-    }
-  }); 
- 
+      if (errors.length > 0) {
+        console.log(errors.join("\n"));
+        page.render("error.png");
+        phantom.exit(1);
+      } else {
+        console.log("Ok.");
+        phantom.exit(0);
+      }
+    });
+  }, 1000);
 }
 
 exports.runTests = runTests;


### PR DESCRIPTION
- Use simplehttpserver instead of python server
- Use npm to run the tests
- Copy hinclude.js source file with npm
- Add 1000 ms timeout to test framework, due to historical flaky tests
- Move port config to environment variable usage