### PR TITLE
Preserve class attribute and add 'included' class name

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -43,7 +43,9 @@ var hinclude;
         if (req.status === 200 || req.status === 304) {
           element.innerHTML = req.responseText;
         }
-        element.className = hinclude.classprefix + req.status;
+
+        hinclude.set_class(element, req.status);
+
         hinclude.trigger_event(element);
       }
     },
@@ -66,7 +68,7 @@ var hinclude;
         if (include[1].status === 200 || include[1].status === 304) {
           include[0].innerHTML = include[1].responseText;
         }
-        include[0].className = hinclude.classprefix + include[1].status;
+        hinclude.set_class(include[0], include[1].status);
         hinclude.trigger_event(include[0]);
       }
     },
@@ -235,6 +237,16 @@ var hinclude;
         event.eventName = "hinclude";
         element.fireEvent("on" + event.eventType, event);
       }
+    },
+
+    set_class: function (element, status) {
+      var tokens = element.className.split(/\s+/);
+      var otherClasses = tokens.filter(function(token){
+        return !token.match(/^include_\d+$/i) && !token.match(/^included/i);
+      }).join(' ');
+
+      element.className = otherClasses + (otherClasses ? ' ' : '') +
+        'included ' + hinclude.classprefix + status;
     }
   };
 

--- a/hinclude.js
+++ b/hinclude.js
@@ -241,7 +241,7 @@ var hinclude;
 
     set_class: function (element, status) {
       var tokens = element.className.split(/\s+/);
-      var otherClasses = tokens.filter(function(token){
+      var otherClasses = tokens.filter(function (token) {
         return !token.match(/^include_\d+$/i) && !token.match(/^included/i);
       }).join(' ');
 


### PR DESCRIPTION
- Only remove class names that match 'include_', which allows for
    styling of hincludes.
- Add an 'included' class in after content is set, which allows for
    hiding non-included hincludes with CSS. Check this gist for
    example user code: https://gist.github.com/gustafnk/e42be44d70ae9532b1987c1bcbe95da5