### PR TITLE
onreadystatechanged IE

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -198,12 +198,10 @@ var hinclude;
         }
         // for Internet Explorer
         /*@cc_on
-        document.write(
-          "<scr"
-            + "ipt id=__ie_onload defer src='//:'><\/scr"
-            + "ipt>"
-        );
-        var script = document.getElementById("__ie_onload");
+        var script = document.createElement('script');
+        script.id = '__ie_onload';
+        script.setAttribute("defer", "defer");
+        document.getElementsByTagName('head')[0].appendChild(script);
         script.onreadystatechange = function () {
           if (this.readyState === "complete") {
             init(); // call the onload handler


### PR DESCRIPTION
Olders IE Browsers throw errors: 
UncaughtException: Unable to set property 'onreadystatechange' of undefined or null reference