### PR TITLE
Fix callback closure scope

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -68,7 +68,7 @@ var hinclude;
         include = hinclude.buffer.pop();
         if (include[1].status === 200 || include[1].status === 304) {
           include[0].innerHTML = include[1].responseText;
-          this.eval_js(include[0]);
+          hinclude.eval_js(include[0]);
         }
         hinclude.set_class(include[0], include[1].status);
         hinclude.trigger_event(include[0]);

--- a/hinclude.js
+++ b/hinclude.js
@@ -42,7 +42,7 @@ var hinclude;
       if (req.readyState === 4) {
         if (req.status === 200 || req.status === 304) {
           element.innerHTML = req.responseText;
-          this.eval_js(element);
+          hinclude.eval_js(element);
         }
 
         hinclude.set_class(element, req.status);


### PR DESCRIPTION
I catch error:

```
Uncaught TypeError: Cannot read property 'eval_js' of undefined
    at set_content_async
    at XMLHttpRequest.s.onreadystatechange
```

The problem is that the closure scope is lost.