### PR TITLE
mv simplehttpserver to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,11 @@
   ],
   "dependencies" : {
     "copyfiles": "^0.2.1",
-    "jslint"   :  "*",
-    "simplehttpserver": "^0.1.1"
+    "jslint"   :  "*"
   },
+  "devDependencies": {
+    "simplehttpserver": "^0.1.1"
+  }
   "engines": {
     "node": ">= 0.6.0"
   },


### PR DESCRIPTION
If I see that right then the package "simplehttpserver" will only be used for testing and on the productive environment it does not need to be on it.

simplehttpserver has some security holes. Please refer https://snyk.io/test/npm/simplehttpserver/0.1.1