### PR TITLE
Use valid HTML markup

### DIFF
--- a/hinclude.js
+++ b/hinclude.js
@@ -93,10 +93,7 @@ var hinclude;
       var i = 0;
       var mode = this.get_meta("include_mode", "buffered");
       var callback;
-      this.includes = document.getElementsByTagName("hx:include");
-      if (this.includes.length === 0) { // remove ns for IE
-        this.includes = document.getElementsByTagName("include");
-      }
+      this.includes = document.querySelectorAll('[data-hinclude-src]');
       if (mode === "async") {
         callback = this.set_content_async;
       } else if (mode === "buffered") {
@@ -106,7 +103,7 @@ var hinclude;
       }
 
       for (i; i < this.includes.length; i += 1) {
-        this.include(this.includes[i], this.includes[i].getAttribute("src"), this.includes[i].getAttribute("media"), callback);
+        this.include(this.includes[i], this.includes[i].getAttribute("data-hinclude-src"), this.includes[i].getAttribute("media"), callback);
       }
     },
 


### PR DESCRIPTION
Modified code so it searches for normal 'div' elements, with a 'data-hinclude-src' attribute, instead of 'hx:include' elements with 'src' attributes, which is invalid markup that doesn't meet accessibility requirements.