### PR TITLE
Use HTTPS URLs to avoid a mixed content warning

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 </head>
 <body>
 
-  <a href="http://github.com/mnot/hinclude"><img style="position: absolute; top: 0; right: 0; border: 0;" src="http://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
+  <a href="https://github.com/mnot/hinclude"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub" /></a>
 
 <div id="main">
 
@@ -20,7 +20,7 @@
 
 <p class="intro">Tired of regenerating HTML pages from templates? Want more from Web caches? <strong>HInclude</strong> makes one thing very easy; including other bits of HTML into your Web page, <em>using the browser</em>.</p>
 
-<p><em>See also <a href="https://github.com/gustafnk/h-include">Gustaf Nilsson Kotte's h-include</a> - it uses <a href="http://webcomponents.org">Web Components</a> to do the same thing.</em></p>
+<p><em>See also <a href="https://github.com/gustafnk/h-include">Gustaf Nilsson Kotte's h-include</a> - it uses <a href="https://www.webcomponents.org/">Web Components</a> to do the same thing.</em></p>
 
 <h2>The Basics</h2>
 


### PR DESCRIPTION
The important one to avoid the warning is the image source. The update of link targets is to avoid unnecessary redirects.